### PR TITLE
Investigate and fix form submit errors

### DIFF
--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -1,8 +1,32 @@
 export async function cloudInvoke(functionName: string, body: any): Promise<any> {
-  const response = await fetch(`/api/${functionName}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  return response.json();
+  try {
+    const response = await fetch(`/api/${functionName}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    // Always read as text first to avoid JSON parse crashes when HTML is returned (e.g., 200 index.html)
+    const raw = await response.text();
+
+    try {
+      const data = raw ? JSON.parse(raw) : {};
+      // If server responded with non-OK status but JSON body, surface as error consistently
+      if (!response.ok && (data as any)?.error === undefined) {
+        return { error: "Request failed", status: response.status };
+      }
+      return data;
+    } catch {
+      // Not JSON (likely HTML fallback or empty). Return a normalized error instead of throwing.
+      return {
+        error: "Unexpected non-JSON response from server",
+        status: response.status,
+      };
+    }
+  } catch (err) {
+    return { error: (err as Error)?.message || "Network error" };
+  }
 }


### PR DESCRIPTION
Make `cloudInvoke` more robust to handle non-JSON and error responses, preventing form submission errors caused by unexpected server replies.

The previous implementation would crash when the server returned non-JSON content (e.g., HTML for a 200 OK status, or a 500 error page) instead of a JSON object, leading to repeated form submission failures. This change ensures that `cloudInvoke` always returns a consistent `{ error, status }` object, allowing callers to handle all response types gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-a14d6da9-38cb-46c2-bf02-e85ed2065554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a14d6da9-38cb-46c2-bf02-e85ed2065554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

