### PR TITLE
Remove google tag manager snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,15 +79,6 @@
     
     <!-- Preload critical hero image removed to avoid asset path issues during build -->
     
-    <!-- Google tag (gtag.js) - Async & non-blocking -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17626733867"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'AW-17626733867');
-    </script>
-    
     <!-- Meta Pixel Code removed for performance - was not configured -->
     <meta property="og:title" content="Shriram Properties Park 63 – Premium 3 BHK Apartments in Chennai">
   <meta name="twitter:title" content="Shriram Properties Park 63 – Premium 3 BHK Apartments in Chennai">


### PR DESCRIPTION
Remove the specified Google Tag Manager (GTM) snippet from `index.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c4a58b4-f884-4332-8a80-34dd09bdd341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c4a58b4-f884-4332-8a80-34dd09bdd341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the Google Ads gtag.js snippet from `index.html` while leaving other SEO and GTM code intact.
> 
> - **HTML (`index.html`)**:
>   - Remove Google Ads `gtag.js` async script and inline `gtag` config block (`AW-17626733867`).
>   - Retain existing meta tags and GTM/noscript sections unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77d6c6e3490548f29701631a5faf31a451796fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->